### PR TITLE
Support ECDSA keys

### DIFF
--- a/tools/sdc-docker-setup.sh
+++ b/tools/sdc-docker-setup.sh
@@ -516,7 +516,16 @@ csrPath=$certDir/csr.pem
 caPath=$certDir/ca.pem
 
 mkdir -p $(dirname $keyPath)
-openssl rsa -in $sshPrivKeyPath -outform pem >$keyPath 2>/dev/null
+# 
+# Check to see if the given private key is ECDSA or RSA
+#
+keyType=$(ssh-keygen -lf $sshPrivKeyPath | grep ECDSA)
+if [[ -z "$keyType" ]]; then
+    openssl rsa -in $sshPrivKeyPath -outform pem >$keyPath 2>/dev/null
+else
+    openssl ec -in $sshPrivKeyPath -outform pem >$keyPath 2>/dev/null
+fi
+
 
 certSubject=
 if [[ -n "$(which uname 2>/dev/null)" && "$(uname)" == MINGW* ]]; then


### PR DESCRIPTION
I am trying to use all ECDSA keys on my newer instances.  I am using `ssh-keygen -t ecdsa -m PEM` to create them, and to be able to successfully generate a certificate I needed to update the openssl command to read the key.  Happy to modify this if there is a better way.